### PR TITLE
emit 'any' with 2nd parameter for 'remove' event

### DIFF
--- a/src/beholder.coffee
+++ b/src/beholder.coffee
@@ -184,7 +184,7 @@ class Beholder extends EventEmitter
     @files = (i for i in @files when i.name isnt file.name)
     @dirs = (i for i in @dirs when i.name isnt file.name)
     @emit('remove', file.name) unless silent
-    @emit('any', file.name) unless silent
+    @emit('any', file.name, 'remove') unless silent
     file.watcher = null
     file = null
 


### PR DESCRIPTION
When listening for the 'any' event, the 2nd parameter was undefined where it should have been 'remove'. Adding it back for consistency.
