### PR TITLE
fix broken unwatch with Node v0.10.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "devDependencies": {
     "mocha": "~1.8.1",
-    "coffee-script": "~1.6.3"
+    "coffee-script": "~1.6.3",
+    "mkdirp": "^0.3.5"
   },
   "engines": {
     "node": ">=0.8"

--- a/src/beholder.coffee
+++ b/src/beholder.coffee
@@ -165,7 +165,7 @@ class Beholder extends EventEmitter
       @emit 'any', filePath, event
       @emit event, filePath
 
-      @removeWatch filePath, true
+      @removeWatch file, true
       @addFile filePath, stats, true
 
       file = null

--- a/test/remove.coffee
+++ b/test/remove.coffee
@@ -2,6 +2,7 @@ assert   = require 'assert'
 fs       = require 'fs'
 path     = require 'path'
 beholder = require '../lib/beholder'
+mkdirp   = require 'mkdirp'
 
 pattern = path.join __dirname, 'fixtures/remove/**/*'
 
@@ -19,7 +20,8 @@ describe 'Remove events', ->
   before ->
     for file, i in newFiles
       newFiles[i] = path.join(__dirname, file)
-      try fs.writeFileSync newFiles[i], 'test'
+      mkdirp.sync path.dirname(newFiles[i])
+      fs.writeFileSync newFiles[i], 'test'
 
   it 'should emit events on file deletion', (done) ->
 


### PR DESCRIPTION
fixes https://github.com/cmoncrief/beholder/issues/2

removeWatch is expecting the file object not just the filePath.

I added mkdirp as a dev dependency and updated the tests to use it to create the test file paths when they don't exist.
